### PR TITLE
Implement session tokens

### DIFF
--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -96,8 +96,9 @@ module V1
     def login
       user = User.find_by_email!(@json[:email])
       user.authenticate!(@json[:password])
+      user.create_session_token!
 
-      @session = 'session'
+      @session_token = user.session_token
     rescue ActiveRecord::RecordNotFound => e
       raise Exceptions::V1ApiNotFoundError.new(e, 'email', @json[:email])
     rescue ArgumentError => e

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -3,6 +3,11 @@
 ##
 class Token < ApplicationRecord
   ##
+  # Associations
+  ##
+  has_one(:user, foreign_key: :session_token)
+
+  ##
   # Callbacks
   ##
   before_validation(:generate_token)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,11 @@ class User < ApplicationRecord
   has_secure_password
 
   ##
+  # Associations
+  ##
+  belongs_to(:token, foreign_key: :session_token, optional: true)
+
+  ##
   # Validations
   ##
   validates(:name, presence: true)
@@ -70,5 +75,23 @@ class User < ApplicationRecord
     params[:email] = params.delete(:new_email) if params.key?(:new_email)
 
     update!(params)
+  end
+
+  ##
+  # Generate a new session token
+  ##
+  def create_session_token!
+    expires = Time.now.utc + 6.hours
+    token = Token.create!(expires: expires)
+
+    update!(session_token: token.id)
+  end
+
+  ##
+  # Getter for session_token
+  ##
+  def session_token
+    return nil if self[:session_token].nil?
+    return Token.find(self[:session_token])
   end
 end

--- a/app/views/v1/users/login.json.jbuilder
+++ b/app/views/v1/users/login.json.jbuilder
@@ -1,1 +1,1 @@
-json.session(@session)
+json.session(@session_token.token)

--- a/db/migrate/20160906095625_add_session_token_to_users.rb
+++ b/db/migrate/20160906095625_add_session_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddSessionTokenToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column(:users, :session_token, :integer, index: true)
+    add_foreign_key(:users, :tokens, column: :session_token)
+  end
+end

--- a/db/migrate/20160906110757_add_index_to_tokens_token.rb
+++ b/db/migrate/20160906110757_add_index_to_tokens_token.rb
@@ -1,0 +1,5 @@
+class AddIndexToTokensToken < ActiveRecord::Migration[5.0]
+  def change
+    add_index(:tokens, :token, unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160906081130) do
+ActiveRecord::Schema.define(version: 20160906110757) do
 
   create_table "data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "sensor_type",                                     null: false
@@ -49,7 +49,10 @@ ActiveRecord::Schema.define(version: 20160906081130) do
     t.string   "password_digest", null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.integer  "session_token"
+    t.index ["session_token"], name: "fk_rails_5811ce5925", using: :btree
   end
 
   add_foreign_key "data", "devices"
+  add_foreign_key "users", "tokens", column: "session_token"
 end

--- a/test/controllers/v1/users_controller_test.rb
+++ b/test/controllers/v1/users_controller_test.rb
@@ -346,13 +346,20 @@ module V1
     ##
     test 'login user success' do
       data = LOGIN_DATA.deep_dup
-      expected = {
-        session: 'session'
-      }
+      now = Time.now.utc
 
       post(:login, body: data.to_json)
+      body = JSON.parse(response.body)
 
-      assert_equal(expected.to_json, response.body)
+      assert_equal(true, body.key?('session'))
+
+      # test expiry of session token
+      token = Token.find_by_token!(body['session'])
+      expires = Time.parse(token.expires).utc
+      diff = ((expires - now) / 1.hour).round
+
+      assert_equal(6, diff)
+
       assert_equal('application/json', response.content_type)
       assert_response(:ok)
     end

--- a/test/models/token_test.rb
+++ b/test/models/token_test.rb
@@ -80,7 +80,7 @@ class TokenTest < ActiveSupport::TestCase
     token = Token.first!
 
     assert_raises(ActiveRecord::RecordInvalid) do
-      Token.create(token: token.token)
+      Token.create!(token: token.token)
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -265,4 +265,18 @@ class UserTest < ActiveSupport::TestCase
       user.change_password!(old_password, new_password)
     end
   end
+
+  ##
+  # Test generation of session token and when it expires
+  ##
+  test 'generate session_token' do
+    user = User.first!
+    user.create_session_token!
+    now = Time.now.utc
+    expires = Time.parse(user.session_token.expires).utc
+    diff = ((expires - now) / 1.hour).round
+
+    assert_instance_of(Token, user.session_token)
+    assert_equal(6, diff)
+  end
 end


### PR DESCRIPTION
Adds session tokens for users, to be used when logging in via the API.

Also adds index to `tokens.token` to fix failing test for duplicate tokens.
